### PR TITLE
Initial support for '&&' operator used for arrays in PostgreSQL.

### DIFF
--- a/src/PHPixie/Database/Driver/PDO/Adapter/Pgsql/Parser/Operator.php
+++ b/src/PHPixie/Database/Driver/PDO/Adapter/Pgsql/Parser/Operator.php
@@ -10,7 +10,8 @@ class Operator extends \PHPixie\Database\Type\SQL\Parser\Operator
      * @var array
      */
     protected $additionalOperators = array(
-        'compare'   => array('>>', '>>=', '<<', '<<=', '&&',),
+        'compare'   => array('>>', '>>=', '<<', '<<=',),
+        'array'     => array('overlap', '&&','contains', '@>', 'contained', '<@'),
     );
 
     /**
@@ -25,7 +26,60 @@ class Operator extends \PHPixie\Database\Type\SQL\Parser\Operator
             $this->operators['compare'],
             $this->additionalOperators['compare']
         );
+        $this->operators['array'] = $this->additionalOperators['array'];
 
         parent::__construct($database, $fragmentParser);
+    }
+
+    /**
+     * Parse array related operators
+     *
+     * @param string $field
+     * @param string $operator
+     * @param mixed $values
+     *
+     * @return \PHPixie\Database\Type\SQL\Expression
+     */
+    protected function parseArray($field, $operator, $values)
+    {
+        $value = $this->validateArrayValue(
+            (array) $this->singleValue($values, $operator)
+        );
+
+        switch ($operator) {
+            case 'overlap':
+                $operator = '&&';
+                break;
+            case 'contains':
+                $operator = '@>';
+                break;
+            case 'contained':
+                $operator = '<@';
+        }
+
+        $expr = $this->prefix($field, $operator);
+        $expr->sql .= '?';
+        $expr->params[] = '{' . implode(',', $value) . '}';
+
+        return $expr;
+    }
+
+    /**
+     * Validate if given array can be used in array operators
+     *
+     * @param array $values
+     *
+     * @return array
+     * @throws \PHPixie\Database\Exception\Parser
+     */
+    protected function validateArrayValue(array $values)
+    {
+        foreach ($values as $val) {
+            if (!is_int($val)) {
+                throw new \PHPixie\Database\Exception\Parser("Currently only int values are supported in arrays.");
+            }
+        }
+
+        return $values;
     }
 }

--- a/src/PHPixie/Database/Driver/PDO/Adapter/Pgsql/Parser/Operator.php
+++ b/src/PHPixie/Database/Driver/PDO/Adapter/Pgsql/Parser/Operator.php
@@ -10,7 +10,7 @@ class Operator extends \PHPixie\Database\Type\SQL\Parser\Operator
      * @var array
      */
     protected $additionalOperators = array(
-        'compare'   => array('>>', '>>=', '<<', '<<=',),
+        'compare'   => array('>>', '>>=', '<<', '<<=', '&&',),
     );
 
     /**

--- a/src/PHPixie/Database/Type/SQL/Parser/Operator.php
+++ b/src/PHPixie/Database/Type/SQL/Parser/Operator.php
@@ -4,7 +4,14 @@ namespace PHPixie\Database\Type\SQL\Parser;
 
 abstract class Operator extends \PHPixie\Database\Parser\Operator
 {
+    /**
+     * @var \PHPixie\Database
+     */
     protected $database;
+
+    /**
+     * @var \PHPixie\Database\Type\SQL\Parser\Fragment
+     */
     protected $fragmentParser;
 
     protected $operators = array(

--- a/tests/PHPixie/Tests/Database/Driver/PDO/Adapter/Pgsql/Parser/OperatorTest.php
+++ b/tests/PHPixie/Tests/Database/Driver/PDO/Adapter/Pgsql/Parser/OperatorTest.php
@@ -35,8 +35,26 @@ class OperatorTest extends \PHPixie\Tests\Database\Type\SQL\Parser\OperatorTest
         array('"a" >>= ?', array(1)),
         array('"a" << ?', array(1)),
         array('"a" <<= ?', array(1)),
-        array('"a" && ?', array('{1}')),
+        array('"a" && ?', array('{1}')), // single value instead of array
+        array('"a" && ?', array('{1,2,3}')),
+        array('"a" && ?', array('{1,2,3}')),
+        array('"a" @> ?', array('{1,2,3}')),
+        array('"a" @> ?', array('{1,2,3}')),
+        array('"a" <@ ?', array('{1,2,3}')),
+        array('"a" <@ ?', array('{1,2,3}')),
     );
+
+    /**
+     * @inheritdoc
+     */
+    protected function exceptionConditions()
+    {
+        return array_merge(parent::exceptionConditions(),
+            array(
+                $this->operator('a', '&&', array(array('text not supported'))),
+            )
+        );
+    }
 
     /**
      * @inheritdoc
@@ -50,7 +68,13 @@ class OperatorTest extends \PHPixie\Tests\Database\Type\SQL\Parser\OperatorTest
                 $this->operator('a', '>>=', array(1)),
                 $this->operator('a', '<<', array(1)),
                 $this->operator('a', '<<=', array(1)),
-                $this->operator('a', '&&', array('{1}')),
+                $this->operator('a', '&&', array(1)), // single value instead of array
+                $this->operator('a', '&&', array(array(1, 2, 3))),
+                $this->operator('a', 'overlap', array(array(1, 2, 3))),
+                $this->operator('a', '@>', array(array(1, 2, 3))),
+                $this->operator('a', 'contains', array(array(1, 2, 3))),
+                $this->operator('a', '<@', array(array(1, 2, 3))),
+                $this->operator('a', 'contained', array(array(1, 2, 3))),
             )
         );
     }

--- a/tests/PHPixie/Tests/Database/Driver/PDO/Adapter/Pgsql/Parser/OperatorTest.php
+++ b/tests/PHPixie/Tests/Database/Driver/PDO/Adapter/Pgsql/Parser/OperatorTest.php
@@ -35,6 +35,7 @@ class OperatorTest extends \PHPixie\Tests\Database\Type\SQL\Parser\OperatorTest
         array('"a" >>= ?', array(1)),
         array('"a" << ?', array(1)),
         array('"a" <<= ?', array(1)),
+        array('"a" && ?', array('{1}')),
     );
 
     /**
@@ -49,6 +50,7 @@ class OperatorTest extends \PHPixie\Tests\Database\Type\SQL\Parser\OperatorTest
                 $this->operator('a', '>>=', array(1)),
                 $this->operator('a', '<<', array(1)),
                 $this->operator('a', '<<=', array(1)),
+                $this->operator('a', '&&', array('{1}')),
             )
         );
     }

--- a/tests/PHPixie/Tests/Database/Type/SQL/Parser/OperatorTest.php
+++ b/tests/PHPixie/Tests/Database/Type/SQL/Parser/OperatorTest.php
@@ -31,6 +31,11 @@ abstract class OperatorTest extends \PHPixie\Tests\Database\Parser\OperatorTest
         }
     }
 
+    /**
+     * Prepare conditions that should fire \PHPixie\Database\Exception\Parser
+     *
+     * @return array
+     */
     protected function exceptionConditions()
     {
         $conditions = array(


### PR DESCRIPTION
Very basic support. Not very convenient, because at this level, all array conversion have to be done in app:
```
        $items = $this->query('item')
            ->where('categories_ids', '&&', '{' . $category->id() . '}')
            ->find()
        ;
```
or
```
        $items = $this->query('item')
            ->where('categories_ids', '&&', '{' . implode(',' $ids) . '}')
            ->find()
        ;
```

But it is already working and allows to use pgsql arrays. Ideally, it should be 

```
        $ids = array(1, 2, 3);
        $items = $this->query('item')
            ->where('categories_ids', '&&', $ids)
            ->find()
        ;
```
But there are two major stoppers for me:
- arrays in pgsql could be nested(but I can avoid this, saying that I will deal only with "flat" arrays)
- more importantly, I don't know where to put this conversion. And this conversion should be two way and support should be not only for `&&` operator, but also for `select`, `insert`, `update`, `delete` and, probably, somewhere else also.

As an option, I can start with baby steps. Add conversion just for `&&` operator, for example. But I need some guidance here :)